### PR TITLE
fix: add 30s timeout to stdin reads to prevent indefinite hangs

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,6 +17,10 @@ export class ApiError extends Error {
   }
 }
 
+export class ValidationError extends Error {
+  readonly _tag = "ValidationError";
+}
+
 export class TimeoutError extends Error {
   readonly _tag = "TimeoutError";
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,3 +16,7 @@ export class ApiError extends Error {
     super(message);
   }
 }
+
+export class TimeoutError extends Error {
+  readonly _tag = "TimeoutError";
+}


### PR DESCRIPTION
Addresses issue #6 by adding Effect.timeout to stdin operations in both search and extract commands. If stdin is not closed within 30 seconds, a TimeoutError is thrown with a clear message.

Changes:
- Add TimeoutError class to src/errors.ts
- Wrap readStdin() calls with Effect.timeout (30s)
- Apply timeout to both search and extract commands
- Use Effect TS patterns (Duration, catchTag)